### PR TITLE
Fix response surface lookup

### DIFF
--- a/experiments/visualization/publication_plots.py
+++ b/experiments/visualization/publication_plots.py
@@ -327,15 +327,22 @@ class PublicationVisualizationPipeline:
         for idx, (param1, param2) in enumerate(param_pairs):
             ax = fig.add_subplot(gs[0, idx])
             
-            # Get sensitivity data
-            if response_var in sensitivity_results:
-                data = sensitivity_results[response_var]
+            # Get sensitivity data from nested response_surfaces key
+            if response_var in sensitivity_results['response_surfaces']:
+                data = sensitivity_results['response_surfaces'][response_var]
                 
                 # Create scatter plot with color-coded response
                 if 'samples' in data:
-                    x_vals = [sample[param1] for sample in data['samples']]
-                    y_vals = [sample[param2] for sample in data['samples']]
-                    z_vals = [sample[response_var] for sample in data['samples']]
+                    filtered = [
+                        sample for sample in data['samples']
+                        if param1 in sample and param2 in sample and response_var in sample
+                    ]
+                    if not filtered:
+                        continue
+
+                    x_vals = [sample[param1] for sample in filtered]
+                    y_vals = [sample[param2] for sample in filtered]
+                    z_vals = [sample[response_var] for sample in filtered]
                     
                     scatter = ax.scatter(x_vals, y_vals, c=z_vals, cmap='viridis', alpha=0.7)
                     ax.set_xlabel(param1.replace('_', ' ').title())


### PR DESCRIPTION
## Summary
- fix key path for sensitivity results
- skip samples missing required keys when plotting parameter sensitivity

## Testing
- `python - <<'PY'
from experiments.visualization.publication_plots import PublicationVisualizationPipeline
import os
pipeline=PublicationVisualizationPipeline(output_dir='temp_output2')
sensitivity_results={
    'response_surfaces': {
        'hypervolume': {
            'samples': [
                {'insertion_prob': 0.1, 'deletion_prob':0.15, 'phase_exchange_prob':0.2, 'order_exchange_prob':0.3, 'hypervolume': 0.6},
                {'insertion_prob':0.2, 'deletion_prob':0.1, 'order_exchange_prob':0.2, 'hypervolume': 0.7},
                {'insertion_prob':0.15, 'deletion_prob':0.2, 'phase_exchange_prob':0.1, 'order_exchange_prob':0.4, 'hypervolume': 0.65}
            ]
        }
    },
    'sensitivity_indices': {
        'insertion_prob': {'correlation': 0.45, 'p_value': 0.02},
        'deletion_prob': {'correlation': 0.38, 'p_value':0.04},
        'phase_exchange_prob': {'correlation':0.25, 'p_value':0.15},
        'order_exchange_prob': {'correlation':0.3, 'p_value':0.08}
    }
}
print('Running generation...')
pipeline.generate_figure_5_parameter_sensitivity(sensitivity_results)
print('Done. outputs:', os.listdir('temp_output2/figures'))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_684bc0d6cd208325a88b2e2abe570759