### PR TITLE
Ensure per-individual motion history in VEGA

### DIFF
--- a/experiments/core/run_evolution.py
+++ b/experiments/core/run_evolution.py
@@ -291,6 +291,7 @@ def run_evolution_loop(env, robot, vega, max_iterations, verbose=True, simulatio
                         # Choose next individual or evolve population
                         if vega.iteration < vega.gan:
                             vega.gai = vega.iteration % vega.gan
+                            vega.clear_motion_history()
                         else:
                             vega.evolve()  # gai updated inside evolve
 
@@ -388,6 +389,7 @@ def save_evolution_results(vega, results, args):
         best_forward_idx = np.argmax(vega.fitness[:, 0])
         
         vega.gai = best_stability_idx
+        vega.clear_motion_history()
         stability_controller_path = vega.save_best_controller()
         
         # Generate summary

--- a/src/evolution/vega.py
+++ b/src/evolution/vega.py
@@ -130,6 +130,10 @@ class VEGA:
         config_file = os.path.join(self.log_dir, 'config.json')
         with open(config_file, 'w') as f:
             json.dump(config, f, indent=2)
+
+    def clear_motion_history(self):
+        """Reset the stored motion history used for smoothness calculation."""
+        self.motion_history = []
     
     def initialize_populations(self):
         """Initialize populations with better diversity."""
@@ -533,6 +537,7 @@ class VEGA:
             self._apply_order_exchange_mutation(g1)
         
         self.gai = g1
+        self.clear_motion_history()
         self.logger.info(f"Individual {self.gai} selected for {obj_names[h]}")
     
     def _apply_insertion_mutation(self, individual):


### PR DESCRIPTION
## Summary
- add `clear_motion_history` helper on VEGA
- reset motion history whenever `gai` changes in `evolve`
- clear motion history when selecting a new individual in the evolution loop

## Testing
- `pytest -q` *(fails: ImportError: libscipy_openblas64_-56d6093b.so)*

------
https://chatgpt.com/codex/tasks/task_b_684e210953188325906d222b836678dc