### PR TITLE
Add gait closure penalty for VEGA smoothness

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The robot model features a main body with multiple articulated legs, each with m
 - Visualization tools for analyzing robot motion and evolution progress
 - TensorBoard integration for neural network training analysis
 - Comprehensive logging and data collection
+- Continuity penalty that discourages abrupt jumps when a gait cycle repeats
 
 ## Installation
 

--- a/src/evolution/vega.py
+++ b/src/evolution/vega.py
@@ -280,6 +280,9 @@ class VEGA:
         smoothness_fitness = self._calculate_normalized_smoothness_fitness(
             robot, robot_state, displacement
         )
+        closure_penalty = self._cycle_closure_penalty(self.gai)
+        smoothness_fitness *= math.exp(-closure_penalty * 2.0)
+        smoothness_fitness = float(np.clip(smoothness_fitness, 0, 1))
         
         # 5. Direction Control (normalized to [0, 1])
         direction_fitness = math.exp(-direction_error**2)  # Already in [0,1]
@@ -479,6 +482,20 @@ class VEGA:
 
         # Already normalized to [0, 1]
         return contacts / robot.leg_count
+
+    def _cycle_closure_penalty(self, idx):
+        """Penalty for discontinuity between first and last poses."""
+        length = int(self.host_lengths[idx])
+        if length < 2:
+            return 0.0
+
+        start_pose = self.hosts[idx, 0]
+        end_pose = self.hosts[idx, length - 1]
+
+        diff = np.abs(end_pose - start_pose)
+        norm_diff = diff / self.q_range
+        penalty = float(np.mean(norm_diff))
+        return np.clip(penalty, 0.0, 1.0)
 
     def infect_hosts(self):
         """Apply viruses to each host chromosome."""

--- a/tests/test_vega_penalty.py
+++ b/tests/test_vega_penalty.py
@@ -1,0 +1,27 @@
+import unittest
+import numpy as np
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.evolution.vega import VEGA
+
+class TestCycleClosurePenalty(unittest.TestCase):
+    def test_penalty_reduces_smoothness(self):
+        vega = VEGA(population_size=1, chromosome_length=3, generations=1)
+        idx = 0
+        vega.host_lengths[idx] = 2
+        vega.hosts[idx, 0] = np.zeros((2, vega.dof))
+        vega.hosts[idx, 1] = np.ones((2, vega.dof)) * vega.q_range
+
+        penalty = vega._cycle_closure_penalty(idx)
+        self.assertGreater(penalty, 0)
+
+        base = 1.0
+        penalized = base * math.exp(-penalty * 2.0)
+        self.assertLess(penalized, base)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `_cycle_closure_penalty` to check gait loop continuity
- penalize smoothness fitness when the first and last poses differ
- add unit test verifying penalty impact on smoothness
- document continuity penalty in README