### PR TITLE
Reorder VEGA evolution steps

### DIFF
--- a/src/evolution/vega.py
+++ b/src/evolution/vega.py
@@ -559,17 +559,19 @@ class VEGA:
     
     def evolve(self):
         """Enhanced evolution with better stability focus."""
-        # Viruses mutate and infect hosts before ranking
-        self.mutate_viruses()
-        self.infect_hosts()
+        # Rank population before applying any virus operations
         self.rank()
 
-        # Identify elite individuals based on Pareto ranking
+        # Identify elite individuals based on Pareto ranking prior to mutation
         elite_count = max(1, int(self.gan * self.elite_fraction))
         elite_indices = self.parents[:elite_count]
         elite_hosts = self.hosts[elite_indices].copy()
         elite_lengths = self.host_lengths[elite_indices].copy()
         elite_fitness = self.fitness[elite_indices].copy()
+
+        # Viruses mutate and infect hosts after ranking so elites are preserved
+        self.mutate_viruses()
+        self.infect_hosts()
 
         # Archive elites for reference
         self.elite_archive = [

--- a/src/robot/leg_robot.py
+++ b/src/robot/leg_robot.py
@@ -56,7 +56,14 @@ class LeggedRobot:
         
         # Map joints properly
         self._map_joints()
-        
+
+        # Provide legacy attribute names for compatibility with tests
+        self.leg_ids = list(range(self.leg_count))
+        self.dummy_leg_ids = self.joint2
+        self.joint_ids = [self.leg_joints[i][0] for i in range(self.leg_count)]
+        self.total_legs = self.leg_count
+        self.dummy_legs = self.dleg
+
         # Apply enhanced dynamics to robot
         self._configure_robot_dynamics()
     
@@ -400,3 +407,13 @@ class LeggedRobot:
                 self.body_id, joint_idx,
                 localInertiaDiagonal=[0.0001, 0.0001, 0.0001]
             )
+
+    # Compatibility property used in tests
+    @property
+    def t_angle(self):
+        return self.tang
+
+    @t_angle.setter
+    def t_angle(self, value):
+        self.tang = value
+


### PR DESCRIPTION
## Summary
- rank population before mutating viruses and infecting hosts
- expose compatibility attributes in `LeggedRobot` for tests